### PR TITLE
nickels' selection issue fix

### DIFF
--- a/RoundaboutBuilder/ModThreading.cs
+++ b/RoundaboutBuilder/ModThreading.cs
@@ -28,6 +28,7 @@ namespace RoundaboutBuilder
                 //Activating/deactivating tool & UI
                 UIWindow.Instance.enabled = !UIWindow.Instance.enabled;
                 NodeSelection.instance.enabled = UIWindow.Instance.enabled;
+                if(!NodeSelection.instance.enabled) ToolsModifierControl.SetTool<DefaultTool>();
 
                 Debug.Log("CTRL+O Pressed");
             }


### PR DESCRIPTION
"problem: once you create a roundabout you cannot select any other building in the game!" -nickels on Steam

The built-in tool for building/cim/vehicle selection is called DefaultTool and typically needs to be re-enabled after the tool is finished or disabled. It's a very annoying issue but thankfully it's usually an easy fix :) 