### PR TITLE
more elaborate elevation

### DIFF
--- a/RoundaboutBuilder/NetWrappers/WrappedSegment.cs
+++ b/RoundaboutBuilder/NetWrappers/WrappedSegment.cs
@@ -106,7 +106,7 @@ namespace SharedEnvironment
         {
             // See public static ToolBase.ToolErrors NetTool.CreateNode(NetInfo info, NetTool.ControlPoint startPoint, NetTool.ControlPoint middlePoint, NetTool.ControlPoint endPoint, FastList<NetTool.NodePosition> nodeBuffer, int maxSegments, bool test, bool testEnds, bool visualize, bool autoFix, bool needMoney, bool invert, bool switchDir, ushort relocateBuildingID, out ushort firstNode, out ushort lastNode, out ushort segment, out int cost, out int productionRate)
             float elevation1, elevation2;
-            if (StartNode.Id != 0 && EndNode.Id != 0)
+            if (StartNode.IsCreated() && EndNode.IsCreated())
             {
                 // destruction
                 elevation1 = StartNode.Get.m_elevation;

--- a/RoundaboutBuilder/NetWrappers/WrappedSegment.cs
+++ b/RoundaboutBuilder/NetWrappers/WrappedSegment.cs
@@ -105,8 +105,19 @@ namespace SharedEnvironment
         public int ComputeConstructionCost()
         {
             // See public static ToolBase.ToolErrors NetTool.CreateNode(NetInfo info, NetTool.ControlPoint startPoint, NetTool.ControlPoint middlePoint, NetTool.ControlPoint endPoint, FastList<NetTool.NodePosition> nodeBuffer, int maxSegments, bool test, bool testEnds, bool visualize, bool autoFix, bool needMoney, bool invert, bool switchDir, ushort relocateBuildingID, out ushort firstNode, out ushort lastNode, out ushort segment, out int cost, out int productionRate)
-            float elevation1 = NetUtil.GetElevation(StartNode.Position);
-            float elevation2 = NetUtil.GetElevation(EndNode.Position);
+            float elevation1, elevation2;
+            if (StartNode.Id != 0 && EndNode.Id != 0)
+            {
+                // destruction
+                elevation1 = StartNode.Get.m_elevation;
+                elevation2 = EndNode.Get.m_elevation;
+            }
+            else
+            {
+                // construction
+                elevation1 = NetUtil.GetElevation(StartNode.Position, StartNode.NetInfo.m_netAI);
+                elevation2 = NetUtil.GetElevation(EndNode.Position, EndNode.NetInfo.m_netAI);
+            }
             return NetInfo.m_netAI.GetConstructionCost(StartNode.Position, EndNode.Position, elevation1, elevation2);
         }
 

--- a/RoundaboutBuilder/Tools/NetUtil.cs
+++ b/RoundaboutBuilder/Tools/NetUtil.cs
@@ -72,22 +72,27 @@ namespace RoundaboutBuilder.Tools
         public static byte GetElevation(Vector3 position, NetAI net_ai)
         {
             if (!net_ai.IsUnderground() && !net_ai.IsOverground())
-                return 0;
+            {
+                return 0; // on ground.
+            }
             
             net_ai.GetElevationLimits(out int min, out int max);
             if (min == max)
-                return 0;
+            {
+                return 0; // From NetTool.GetElevation()
+            }
 
             float elevation = position.y - TerrainHeight(position);
 
 #if DEBUG
+            // tolerated error = +-1
             if(!(min * 12 - 1 <= elevation && elevation <= max * 12 + 1))
-                Debug.LogWarning($"ELevation out of range expected {min * 12 - 1} <= {elevation} <={max * 12 + 1}");
+                Debug.LogWarning($"RoundaboutBuilder: ELevation out of range expected {min * 12 - 1} <= {elevation} <={max * 12 + 1}");
 #endif
             
-            elevation = Mathf.Clamp(elevation, min * 12, max * 12);
+            elevation = Mathf.Clamp(elevation, min * 12, max * 12); // 12 is from NetTool.GetElevation()
             elevation = Mathf.Abs(elevation);
-            return (byte)Mathf.Clamp(elevation, 1, 255);
+            return (byte)Mathf.Clamp(elevation, 1, 255); // underground/overground road should not have 0 elevation.
         }
 
         public static float TerrainHeight(Vector3 position)


### PR DESCRIPTION
more elaborate `GetElevation()` method:
- checks min max according to NetAI.
- if NetAI is OnGround elevation is always 0. (i tested and elevation always 0 for roads created by NetTool on ground no matter what.)
- elevation is byte value so for underground nodes it stores the absolute value.

Note: for underground roundabout segments with elevation 8 or less:  with FRT in normal mode when user tries to connect a segment, NetTool will build on ground. I have forced minimum underground elevation to be 1.